### PR TITLE
"fancy" NTT using Cantor domains

### DIFF
--- a/binius_models/hashes/vision/mds.py
+++ b/binius_models/hashes/vision/mds.py
@@ -45,11 +45,11 @@ class VisionMDSTransformation(Generic[F]):
             # for the general interpolate algorithm, see `binius_crates::ntt::odd_interpolate` in the Binius code.
 
             stash[chunk_size | k] += stash[k]
-            temp_0 = constants[self.log_h][0] * stash[chunk_size | k]
+            temp_0 = constants[self.log_h][1] * stash[chunk_size | k]
             stash[chunk_size << 1 | k] += temp_0 + stash[k]
 
-            temp_1 = constants[self.log_h][1] * stash[chunk_size | k]
-            temp_2 = constants[self.log_h + 1][0] * stash[chunk_size << 1 | k]
+            temp_1 = constants[self.log_h][2] * stash[chunk_size | k]
+            temp_2 = constants[self.log_h + 1][1] * stash[chunk_size << 1 | k]
             result[k] += temp_0 + stash[chunk_size | k] + stash[chunk_size << 1 | k]
             result[chunk_size | k] = stash[k] + temp_1 + temp_2
             result[chunk_size << 1 | k] = result[chunk_size | k] + stash[chunk_size | k]

--- a/binius_models/hashes/vision/test_mds.py
+++ b/binius_models/hashes/vision/test_mds.py
@@ -63,7 +63,7 @@ def test_mds_correctness():
 @pytest.mark.parametrize("field_elem_t", [Elem8bFP, Elem32bFP], ids=["8b", "32b"])
 def test_generated_vision_instance_mds(field_elem_t: Type):
     log_h = 3
-    n_coeffs = 3 * (1 << log_h)
+    n_coeffs = 3 << log_h
     mds = VisionMDSTransformation(field_elem_t, log_h)
 
     input_evals = [mds.field.random() for _ in range(n_coeffs)]

--- a/binius_models/hashes/vision/vision.py
+++ b/binius_models/hashes/vision/vision.py
@@ -117,8 +117,6 @@ class Vision(ABC, Generic[E]):
 
     def sponge_hash(self, message: list[E]) -> list[E]:
         """This assumes the fixed length is the length of the message"""
-        msg_len_bytes = len(message) * self.elem.field.bytes_len
-        
         # pad input using Keccak padding scheme
         padding_len = self.r - (len(message) % self.r)
         padding_bytes = [0] * padding_len * self.elem.field.bytes_len

--- a/binius_models/ntt/additive_ntt.py
+++ b/binius_models/ntt/additive_ntt.py
@@ -220,13 +220,13 @@ class CantorAdditiveNTT(AdditiveNTT[F]):
 class FancyAdditiveNTT(AdditiveNTT[F]):
     # for our S⁽⁰⁾, we're going to take the image in the Fan–Paar field OF the set < 1, 2, 4, ... > in the FAST field.
     # and we can prune a few steps away from _precompute_constants.
-    def _field_to_column(self, element : F, iota : int) -> np.array:
+    def _field_to_column(self, element: F, iota: int) -> np.array:
         return np.array([(element.value >> i) & 1 for i in range(1 << iota)]).reshape(-1, 1)
 
-    def _column_to_field(self, column : np.array, iota : int) -> F:
+    def _column_to_field(self, column: np.array, iota: int) -> F:
         return self.field(sum(column.tolist()[i][0] << i for i in range(1 << iota)))
 
-    def _solve_underdetermined_system(self, products : np.array, affine_constant : np.array, iota : int) -> np.array:
+    def _solve_underdetermined_system(self, products: np.array, affine_constant: np.array, iota: int) -> np.array:
         # the matrices we call this on are guaranteed to be 0 in the leftmost column, and elsewhere of full rank.
         # augmented = galois.FieldArray.row_reduce(np.hstack((products, affine_constant)))
         # return np.insert(augmented[:, -1][:-1], 0, 0).reshape(-1, 1)
@@ -265,10 +265,10 @@ class FancyAdditiveNTT(AdditiveNTT[F]):
 
             # the below is the decomposition, with respect to our basis, of the image, in our field,
             # of the FAST constant monomial X_0 ⋅ ⋯ X_{ι − 2}. put that in your pipe and smoke it!
-            affine_constant = self._field_to_column(self.constants[0][(1 << iota - 1) - 1], iota)  # = self.constants[0][-1]
+            affine_constant = self._field_to_column(self.constants[0][(1 << iota - 1) - 1], iota)
 
             solution = self._solve_underdetermined_system(products, affine_constant, iota)
-            fast_indeterminate = self._column_to_field(solution, iota)  # this is the image of FAST X_{ι – 1} in the FP tower
+            fast_indeterminate = self._column_to_field(solution, iota)  # == image of FAST X_{ι – 1} in the FP tower
             for j in range(min(1 << iota - 1, initial_dimension - (1 << iota - 1))):
                 self.constants[0].append(self.constants[0][j] * fast_indeterminate)
 

--- a/binius_models/ntt/additive_ntt.py
+++ b/binius_models/ntt/additive_ntt.py
@@ -244,7 +244,6 @@ class FancyAdditiveNTT(AdditiveNTT[F]):
         # its columns will be the bit-decompositions in the FP basis of α² + α, for α varying through an 𝔽₂-basis of 𝒯_ι
         products = field.Zeros((1, 1))
         while True:
-            # invariant: it's the number of vectors we still need to add.
             iota += 1
             # begin construction of tower level ι.
             products = np.pad(products, ((0, 1 << iota - 1), (0, 0)), mode="constant", constant_values=0)

--- a/binius_models/ntt/additive_ntt.py
+++ b/binius_models/ntt/additive_ntt.py
@@ -231,7 +231,7 @@ class FancyAdditiveNTT(AdditiveNTT[F]):
         def _column_to_field(column):
             return self.field(sum(column.tolist()[i][0] << i for i in range(1 << iota)))
 
-        def _solve_underdermined_system(products, affine_constant):
+        def _solve_underdetermined_system(products, affine_constant):
             # the matrices we call this on are guaranteed to be 0 in the leftmost column, and elsewhere of full rank.
             augmented = galois.FieldArray.row_reduce(np.hstack((products, affine_constant)))
             return np.insert(augmented[:, -1][:-1], 0, 0).reshape(-1, 1)
@@ -257,7 +257,7 @@ class FancyAdditiveNTT(AdditiveNTT[F]):
             # of the FAST constant monomial X_0 ⋅ ⋯ X_{ι − 2}. put that in your pipe and smoke it!
             affine_constant = _field_to_column(self.constants[0][(1 << iota - 1) - 1], iota)
 
-            solution = _solve_underdermined_system(products, affine_constant)
+            solution = _solve_underdetermined_system(products, affine_constant)
             fast_indeterminate = _column_to_field(solution)  # this is the image of FAST X_{ι – 1} in the FP tower
             for j in range(min(1 << iota - 1, initial_dimension - (1 << iota - 1))):
                 self.constants[0].append(self.constants[0][j] * fast_indeterminate)

--- a/binius_models/ntt/odd_interpolate.py
+++ b/binius_models/ntt/odd_interpolate.py
@@ -34,11 +34,10 @@ class InterpolateNonTwoPrimary(Generic[F]):
         # this will be the thing we want to apply the inverse of stride-wise, after doing ℓ iNTT rounds.
         vandermonde = [[self.field.zero() for _ in range(self.d)] for _ in range(self.d)]
 
-        constants = self.additive_ntt.constants
         for j in range(self.log_d):
             for i in range(j, self.log_d):
                 # first handle the case of power-of-two-valued i and j; these things are our precomputed constants!
-                vandermonde[1 << i][1 << j] = self.field.one() if i == j else constants[j + self.ell][i - j - 1]
+                vandermonde[1 << i][1 << j] = self.additive_ntt.constants[j + self.ell][i - j]
                 # now, i.e. below, we extend by addition / linearity to the case of non-power-of-two-valued i.
                 for k in range(1, min(1 << i, self.d - (1 << i))):  # if 1 << j | k >= self.d: break
                     vandermonde[1 << i | k][1 << j] = vandermonde[k][1 << j] + vandermonde[1 << i][1 << j]

--- a/binius_models/ntt/test_additive_ntt.py
+++ b/binius_models/ntt/test_additive_ntt.py
@@ -137,3 +137,5 @@ def test_fancy_huge(Elem32b: type[BinaryTowerFieldElem]) -> None:
     max_log_h = 27
     log_h = 10
     ntt = FancyAdditiveNTT(Elem32b, max_log_h, 2)
+    input = [ntt.field.random() for _ in range(1 << log_h)]
+    assert ntt.encode(input) == ntt._naive_encode(input)

--- a/binius_models/ntt/test_additive_ntt.py
+++ b/binius_models/ntt/test_additive_ntt.py
@@ -138,9 +138,12 @@ def test_fancy_large() -> None:
     cantor = CantorAdditiveNTT(Elem32bFAST, max_log_h, 2)
     fancy = FancyAdditiveNTT(Elem32bFP, max_log_h, 2)
     input = [Elem16bFAST.random() for _ in range(1 << log_h)]
+
     def convert_element(element: Elem16bFAST) -> Elem16bFP:  # this is only for testing; it's an abuse of "constants"
         column = fancy._field_to_column(element, 4)
         return sum((fancy.constants[0][i] if column[i] else Elem16bFP.zero() for i in range(1 << 4)), Elem16bFP.zero())
+
     def convert_list(input: list[Elem16bFAST]) -> list[Elem16bFP]:
         return [convert_element(element) for element in input]
+
     assert fancy.encode(convert_list(input)) == convert_list(cantor.encode(input))

--- a/binius_models/ntt/test_additive_ntt.py
+++ b/binius_models/ntt/test_additive_ntt.py
@@ -137,5 +137,10 @@ def test_fancy_large() -> None:
     log_h = 7
     cantor = CantorAdditiveNTT(Elem32bFAST, max_log_h, 2)
     fancy = FancyAdditiveNTT(Elem32bFP, max_log_h, 2)
-    input = [fancy.field.random() for _ in range(1 << log_h)]
-    assert fancy.encode(input) == cantor.encode(input)
+    input = [Elem16bFAST.random() for _ in range(1 << log_h)]
+    def convert_element(element: Elem16bFAST) -> Elem16bFP:  # this is only for testing; it's an abuse of "constants"
+        column = fancy._field_to_column(element, 4)
+        return sum((fancy.constants[0][i] if column[i] else Elem16bFP.zero() for i in range(1 << 4)), Elem16bFP.zero())
+    def convert_list(input: list[Elem16bFAST]) -> list[Elem16bFP]:
+        return [convert_element(element) for element in input]
+    assert fancy.encode(convert_list(input)) == convert_list(cantor.encode(input))

--- a/binius_models/ntt/test_additive_ntt.py
+++ b/binius_models/ntt/test_additive_ntt.py
@@ -130,12 +130,12 @@ def test_inverse_interleaved() -> None:
     assert tricky_inverse == naive_inverse
 
 
-@pytest.mark.parametrize("Elem32b", [Elem32bFP])
-def test_fancy_huge(Elem32b: type[BinaryTowerFieldElem]) -> None:
+def test_fancy_large() -> None:
     # length 2⁵, rate 1/4, so 4× in length. note that the block length is only 2⁷ here;
     # the code will "intelligently" know to only do this over the smaller field 𝔽_{2⁸}.
     max_log_h = 27
-    log_h = 10
-    ntt = FancyAdditiveNTT(Elem32b, max_log_h, 2)
-    input = [ntt.field.random() for _ in range(1 << log_h)]
-    assert ntt.encode(input) == ntt._naive_encode(input)
+    log_h = 7
+    cantor = CantorAdditiveNTT(Elem32bFAST, max_log_h, 2)
+    fancy = FancyAdditiveNTT(Elem32bFP, max_log_h, 2)
+    input = [fancy.field.random() for _ in range(1 << log_h)]
+    assert fancy.encode(input) == cantor.encode(input)

--- a/binius_models/ntt/test_additive_ntt.py
+++ b/binius_models/ntt/test_additive_ntt.py
@@ -1,15 +1,20 @@
 import pytest
 
 from ..finite_fields.tower import BinaryTowerFieldElem, FanPaarTowerField, FASTowerField
-from .additive_ntt import AdditiveNTT, CantorAdditiveNTT, FourStepAdditiveNTT
+from .additive_ntt import (
+    AdditiveNTT,
+    CantorAdditiveNTT,
+    FancyAdditiveNTT,
+    FourStepAdditiveNTT,
+)
 
 
 class Elem8bFAST(BinaryTowerFieldElem):
-    field = FASTowerField(4)
+    field = FASTowerField(3)
 
 
 class Elem8bFP(BinaryTowerFieldElem):
-    field = FanPaarTowerField(4)
+    field = FanPaarTowerField(3)
 
 
 class Elem16bFAST(BinaryTowerFieldElem):
@@ -20,8 +25,16 @@ class Elem16bFP(BinaryTowerFieldElem):
     field = FanPaarTowerField(4)
 
 
+class Elem32bFAST(BinaryTowerFieldElem):
+    field = FASTowerField(5)
+
+
+class Elem32bFP(BinaryTowerFieldElem):
+    field = FanPaarTowerField(5)
+
+
 @pytest.mark.parametrize("Elem8b", [Elem8bFP, Elem8bFAST])
-def test_ntt_5_2(Elem8b: type[BinaryTowerFieldElem]) -> None:
+def test_ntt(Elem8b: type[BinaryTowerFieldElem]) -> None:
     # length 2⁵, rate 1/4, so 4× in length. note that the block length is only 2⁷ here;
     # the code will "intelligently" know to only do this over the smaller field 𝔽_{2⁸}.
     log_h = 5
@@ -32,7 +45,7 @@ def test_ntt_5_2(Elem8b: type[BinaryTowerFieldElem]) -> None:
 
 @pytest.mark.slow
 @pytest.mark.parametrize("Elem16b", [Elem16bFP, Elem16bFAST])
-def test_ntt_7_2(Elem16b: type[BinaryTowerFieldElem]) -> None:
+def test_ntt_large(Elem16b: type[BinaryTowerFieldElem]) -> None:
     log_h = 7
     ntt = AdditiveNTT(Elem16b, log_h, 2)
     input = [ntt.field.random() for _ in range(1 << log_h)]
@@ -40,7 +53,7 @@ def test_ntt_7_2(Elem16b: type[BinaryTowerFieldElem]) -> None:
 
 
 @pytest.mark.parametrize("Elem16b", [Elem16bFP, Elem16bFAST])
-def test_four_step_7_2(Elem16b: type[BinaryTowerFieldElem]) -> None:
+def test_four_step_large(Elem16b: type[BinaryTowerFieldElem]) -> None:
     # start with length 2⁷ = 128; 4x it in length, ending with 512
     log_h = 7
     ntt = AdditiveNTT(Elem16b, log_h, 2)
@@ -50,7 +63,7 @@ def test_four_step_7_2(Elem16b: type[BinaryTowerFieldElem]) -> None:
 
 
 @pytest.mark.parametrize("Elem16b", [Elem16bFP, Elem16bFAST])
-def test_four_step_8_4(Elem16b: type[BinaryTowerFieldElem]) -> None:
+def test_four_step_larger(Elem16b: type[BinaryTowerFieldElem]) -> None:
     # start with length 2⁸ = 256; 16x it in length, ending with 4096
     log_h = 8
     ntt = AdditiveNTT(Elem16b, log_h, 4)
@@ -59,7 +72,7 @@ def test_four_step_8_4(Elem16b: type[BinaryTowerFieldElem]) -> None:
     assert four_step.encode(input) == ntt.encode(input)
 
 
-def test_cantor_5_2() -> None:
+def test_cantor() -> None:
     log_h = 5
     ntt = CantorAdditiveNTT(Elem16bFAST, log_h, 2)
     input = [ntt.field.random() for _ in range(1 << log_h)]
@@ -67,7 +80,7 @@ def test_cantor_5_2() -> None:
 
 
 @pytest.mark.slow
-def test_cantor_5_2_fail() -> None:
+def test_cantor_fail() -> None:
     log_h = 5
     ntt = CantorAdditiveNTT(Elem16bFP, log_h, 2)
     # this should NOT work, since Cantor NTT needs a FAST field, not an arbitrary (e.g. Fan–Paar) field.
@@ -115,3 +128,12 @@ def test_inverse_interleaved() -> None:
     )
     naive_inverse = ntt._inverse_transform(tiled, 0)
     assert tricky_inverse == naive_inverse
+
+
+@pytest.mark.parametrize("Elem32b", [Elem32bFP])
+def test_fancy_huge(Elem32b: type[BinaryTowerFieldElem]) -> None:
+    # length 2⁵, rate 1/4, so 4× in length. note that the block length is only 2⁷ here;
+    # the code will "intelligently" know to only do this over the smaller field 𝔽_{2⁸}.
+    max_log_h = 27
+    log_h = 10
+    ntt = FancyAdditiveNTT(Elem32b, max_log_h, 2)

--- a/binius_models/ntt/test_odd_interpolate.py
+++ b/binius_models/ntt/test_odd_interpolate.py
@@ -25,5 +25,4 @@ def test_odd_interpolate(Elem16b: type[BinaryTowerFieldElem], ell: int, d: int) 
     ntt = AdditiveNTT(Elem16b, log_h, 0)
     input = [interpolate.field.random() if i < d << ell else interpolate.field.zero() for i in range(1 << log_h)]
     encoding = ntt.encode(input)
-    result_of_interpolation = interpolate.interpolate(encoding[: d << ell])
-    assert result_of_interpolation == input[: d << ell]
+    assert interpolate.interpolate(encoding[: d << ell]) == input[: d << ell]


### PR DESCRIPTION
this adds a new way of computing the initial domain $S^{(0)}$ in the Fan–Paar tower. Instead of letting it be $\left< \beta_0, \ldots , \beta_{\ell + \mathcal{R} - 1} \right>$, we let it be the isomorphic image of that domain in the FAST field, transported into Fan–Paar. this gives us nice things like normalization for free, and also that small domains are also defined over small fields!

we are able to compute this isomorphism efficiently, using some nice tricks and a bit of linear algebra over $\mathbb{F}_2$. details forthcoming.